### PR TITLE
Fix bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /cmake-build-debug-remote/
 /.vs
 /out/build
+/build/
 *.json

--- a/ascii_art.h
+++ b/ascii_art.h
@@ -1,4 +1,4 @@
-#ifndef MPI_HAMSTER_KILLERS__ASCII_ART_H
+#ifndef MPI_HAMSTER_KILLERS_ASCII_ART_H
 #define MPI_HAMSTER_KILLERS_ASCII_ART_H
 
 static const char header[] = R"(
@@ -10,4 +10,4 @@ static const char header[] = R"(
 )";
 
 
-#endif //MPI_HAMSTER_KILLERS__ASCII_ART_H
+#endif //MPI_HAMSTER_KILLERS_ASCII_ART_H

--- a/gnome.h
+++ b/gnome.h
@@ -52,6 +52,7 @@ class Gnome : public ProcessBase {
   int bloodHunger;
   int swordsNeeded;
   int poisonNeeded;
+  int minValidContractId;
   int currentContractId;
   int swapRank;
   std::vector<Contract> contracts;
@@ -66,8 +67,9 @@ class Gnome : public ProcessBase {
   void doDelegatingPriority();
   void doRampage();
 
+  const Contract& getContractById(int id) const;
   std::vector<int> getAllGnomeRanks() const;
-  std::vector<int> getEmployedGnomeRanks();
+  std::vector<int> getEmployedGnomeRanks() const;
   bool getContract();
   int findSwapCandidate();
   void applySwap(const Swap& swap);

--- a/landlord.cpp
+++ b/landlord.cpp
@@ -77,7 +77,7 @@ void Landlord::doReadGandhi() {
   int contractId = message.contractId;
   isCompleted[contractId - minValidContractId] = true;
   log("I was informed that GNOME %d has murdered all %d hamsters and so completed his contract (ID : %d)",
-      status.source(), contracts[contractId].numberOfHamsters, contractId);
+      status.source(), contracts[contractId - minValidContractId].numberOfHamsters, contractId);
 
   if (std::all_of(isCompleted.begin(), isCompleted.end(), [](bool completed) { return completed; })) {
     state = FINISH;

--- a/landlord.h
+++ b/landlord.h
@@ -12,6 +12,7 @@ class Landlord : public ProcessBase {
   LandlordState state;
   std::vector<Contract> contracts;
   std::vector<bool> isCompleted;
+  int minValidContractId;
 
   void doHire();
   void doReadGandhi();

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@
 #define DEBUG
 
 void signal_callback_handler(int signum) {
-  printf("[Rank: %d] (DEAD): I was wildly killed by unknown force.",
+  printf("[Rank: %d] (DEAD): I was wildly killed by unknown force.\n",
          mpl::environment::comm_world().rank());
 }
 

--- a/mpi_types.h
+++ b/mpi_types.h
@@ -35,7 +35,7 @@ struct RequestForContract : public MessageBase {
 
   bool operator<(const RequestForContract &rhs) const {
     return (bloodHunger == rhs.bloodHunger) ? (timestamp < rhs.timestamp)
-                                            : (bloodHunger < rhs.bloodHunger);
+                                            : (bloodHunger > rhs.bloodHunger);
   }
 
   bool operator==(const RequestForContract &rhs) const {

--- a/process_base.h
+++ b/process_base.h
@@ -51,6 +51,17 @@ class ProcessBase {
   }
 
   template <typename T /* extends MessageBase */>
+  void flush(mpl::tag tag) {
+    T message;
+    auto probe = communicator.iprobe(mpl::any_source, tag);
+    while (probe.first) {
+      auto status = probe.second;
+      communicator.recv(message, status.source(), status.tag());
+      probe = communicator.iprobe(mpl::any_source, tag);
+    }
+  }
+
+  template <typename T /* extends MessageBase */>
   void send(T& message, int recipientRank, mpl::tag tag) {
     lamportClock++;
     setTimestamp(message);


### PR DESCRIPTION
Odbieranie niektórych wiadomości mogło być opóźnione do następnego cyklu, wprowadzając błędy:

CONTRACTS, REQUEST_FOR_CONTRACT - nie dotyczy (odbieranie wszystkich jest częścią algorytmmu).

ALLOCATE_ARMOR, DELEGATE_PRIORITY, SWAP - można czyścić po odebraniu wszystkich REQUEST_FOR_CONTRACT i przed wysłaniem REQUEST_FOR_ARMOR, z własności FIFO wynika, że wszystkie wiadomości tego typu z poprzedniego cyklu będą w tym czasie już dostarczone, a zgodnie z algorytmem nie będą też wysłane z obecnego cyklu (poza ALLOCATE_ARMOR, ale ją można bezpiecznie zignorować).

REQUEST_FOR_ARMOR, CONTRACT_COMPLETED - tu niestety nie ma takiego momentu, w którym na pewno dostarczone są wszystkie z poprzedniego cyklu i jednocześnie żadna z obecnego, ale można je rozróżniać, jeśli id zleceń nie będą się powtarzać pomiędzy cyklami.